### PR TITLE
feat: Aria-activedescendant attribute is now populated by selected option's id

### DIFF
--- a/packages/react-select/src/Select.tsx
+++ b/packages/react-select/src/Select.tsx
@@ -1093,6 +1093,15 @@ export default class Select<
   getOptionValue = (data: Option): string => {
     return getOptionValue(this.props, data);
   };
+  getOptionId = (data: Option | null): string | undefined => {
+    return this.getCategorizedOptions().map((option) => {
+      if (option.type === 'group') {
+        return option.options.map((innerOption) => innerOption);
+      } else {
+        return option;
+      }
+    }).flat().find((option) => option.data === data)?.id;
+  };
   getStyles = <Key extends keyof StylesProps<Option, IsMulti, Group>>(
     key: Key,
     props: StylesProps<Option, IsMulti, Group>[Key]
@@ -1615,13 +1624,7 @@ export default class Select<
 
     const id = inputId || this.getElementId('input');
 
-    const focusedOptionId = this.getCategorizedOptions().map((option) => {
-      if (option.type === 'group') {
-        return option.options.map((innerOption) => innerOption);
-      } else {
-        return option;
-      }
-    }).flat().find((option) => option.data === focusedOption)?.id;
+    const focusedOptionId = this.getOptionId(focusedOption);
 
     // aria attributes makes the JSX "noisy", separated for clarity
     const ariaAttributes = {

--- a/packages/react-select/src/__tests__/Select.test.tsx
+++ b/packages/react-select/src/__tests__/Select.test.tsx
@@ -63,13 +63,13 @@ test('snapshot - defaults', () => {
   expect(container).toMatchSnapshot();
 });
 
-test('instanceId prop > to have instanceId as id prefix for the select components', () => {
+test('instanceId prop > to have instanceId as id prefix for the select components, except options components', () => {
   let { container } = render(
     <Select {...BASIC_PROPS} menuIsOpen instanceId={'custom-id'} />
   );
   expect(container.querySelector('input')!.id).toContain('custom-id');
-  container.querySelectorAll('div.react-select__option').forEach((opt) => {
-    expect(opt.id).toContain('custom-id');
+  container.querySelectorAll('div.react-select__option').forEach((opt, index) => {
+    expect(opt.id).toContain(`${OPTIONS[index].value}-option-${index}`);
   });
 });
 
@@ -1968,21 +1968,16 @@ cases(
       container
         .querySelector('input.react-select__input')!
         .getAttribute('aria-activedescendant')
-    ).toBe('1');
+    ).toBe('zero-option-0');
   },
   {
-    'single select > should update aria-activedescendant as per focused option':
-      {
-        skip: true,
+    'single select > should update aria-activedescendant as per focused option': {},
+    'multi select > should update aria-activedescendant as per focused option': {
+      props: {
+        ...BASIC_PROPS,
+        value: { label: '2', value: 'two' },
       },
-    'multi select > should update aria-activedescendant as per focused option':
-      {
-        skip: true,
-        props: {
-          ...BASIC_PROPS,
-          value: { label: '2', value: 'two' },
-        },
-      },
+    },
   }
 );
 


### PR DESCRIPTION
# TODO

For internal preview only.